### PR TITLE
Add KORG ESX/EMX-1 Web Editor prototype and README entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,27 @@ src/main/java/com/rftrec/
 ```
 
 The project is configured via Gradle and uses Fabric API `0.95.3+1.21`.
+
+## KORG ESX/EMX-1 Web Editor (Prototype)
+
+A standalone browser-based editor UI is available at:
+
+- `web/korg-editor/index.html`
+
+Features:
+- ESX/EMX model switch and hardware-like LED display
+- 10-part sequencer with 16/32/64 pattern lengths + page switch
+- accent + ghost steps (click/right-click/shift-click editing)
+- mixer controls with mute, solo and per-part audition
+- built-in audio preview engine (WebAudio tick playback)
+- undo/redo history and keyboard shortcuts (Space, Ctrl/Cmd+Z, Ctrl/Cmd+Y)
+- ESX/EMX-style themes and local save/load + JSON import/export
+
+To run locally:
+
+```bash
+cd web/korg-editor
+python3 -m http.server 4173
+```
+
+Then open `http://localhost:4173`.

--- a/web/korg-editor/index.html
+++ b/web/korg-editor/index.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>KORG ESX/EMX-1 Web Editor</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="theme-esx">
+    <div class="app-shell">
+      <header class="topbar panel hardware">
+        <div>
+          <p class="brand">KORG ELECTRIBE</p>
+          <h1>ESX / EMX Pattern Editor</h1>
+          <p class="subtitle">Mehr Funktionen: Accent-Steps, Pattern-Längen, Undo/Redo, Audio-Preview</p>
+        </div>
+        <div class="transport">
+          <div class="led-display" id="ledDisplay">A.01 | 128 BPM | STOP</div>
+          <button id="playBtn" class="btn btn-green">▶ PLAY</button>
+          <button id="stopBtn" class="btn">■ STOP</button>
+          <button id="tapBtn" class="btn btn-blue">TAP</button>
+        </div>
+      </header>
+
+      <main class="layout">
+        <section class="panel machine-status">
+          <h2>Machine</h2>
+          <div class="status-grid">
+            <label>Model
+              <select id="modelSelect">
+                <option value="esx">ESX-1 (Sampler)</option>
+                <option value="emx">EMX-1 (Synth)</option>
+              </select>
+            </label>
+            <label>Pattern
+              <input id="patternName" value="A.01 Detroit Bounce" />
+            </label>
+            <label>BPM
+              <input id="bpmInput" type="number" min="40" max="240" value="128" />
+            </label>
+            <label>Swing
+              <input id="swingInput" type="range" min="0" max="100" value="12" />
+            </label>
+            <label>Pattern Length
+              <select id="patternLength">
+                <option value="16">16</option>
+                <option value="32">32</option>
+                <option value="64">64</option>
+              </select>
+            </label>
+            <label>Step Page
+              <select id="pageSelect"></select>
+            </label>
+          </div>
+          <div class="actions-row">
+            <button id="newPatternBtn" class="btn">New Pattern</button>
+            <button id="randomizeBtn" class="btn btn-orange">Randomize</button>
+            <button id="copyBarBtn" class="btn">Copy 1→2</button>
+            <button id="undoBtn" class="btn">Undo</button>
+            <button id="redoBtn" class="btn">Redo</button>
+          </div>
+        </section>
+
+        <section class="panel design-section">
+          <h2>Design</h2>
+          <div class="status-grid">
+            <label>Theme
+              <select id="themeSelect">
+                <option value="theme-esx">ESX Red</option>
+                <option value="theme-emx">EMX Blue</option>
+                <option value="theme-night">Night Studio</option>
+              </select>
+            </label>
+            <label>Master Volume
+              <input id="masterVolume" type="range" min="0" max="100" value="72" />
+            </label>
+          </div>
+          <p class="legend">Step-Bedienung: Click = On/Off · Right-Click = Accent · Shift+Click = Ghost</p>
+        </section>
+
+        <section class="panel step-section">
+          <h2>Step Sequencer</h2>
+          <div class="part-tabs" id="partTabs"></div>
+          <div id="stepGrid" class="step-grid"></div>
+          <div class="sequencer-tools">
+            <button class="btn" data-fill="offbeat">Offbeat</button>
+            <button class="btn" data-fill="four">4 on floor</button>
+            <button class="btn" data-fill="clear">Clear</button>
+          </div>
+        </section>
+
+        <section class="panel mixer-section">
+          <h2>Mixer / Part Parameters</h2>
+          <div class="mixer" id="mixer"></div>
+        </section>
+
+        <section class="panel motion-section">
+          <h2>Motion Sequence</h2>
+          <div class="motion-grid">
+            <label>Filter Cutoff<input type="range" id="cutoff" min="0" max="127" value="78" /></label>
+            <label>Resonance<input type="range" id="resonance" min="0" max="127" value="35" /></label>
+            <label>EG Intensity<input type="range" id="eg" min="0" max="127" value="49" /></label>
+            <label>Decay<input type="range" id="decay" min="0" max="127" value="72" /></label>
+            <label>Pan<input type="range" id="pan" min="-64" max="63" value="0" /></label>
+            <label>Roll Type
+              <select id="rollType">
+                <option>Off</option>
+                <option>1/8</option>
+                <option>1/16</option>
+                <option>1/32</option>
+              </select>
+            </label>
+          </div>
+        </section>
+
+        <section class="panel storage-section">
+          <h2>Pattern Manager</h2>
+          <div class="storage-actions">
+            <button id="saveLocalBtn" class="btn btn-green">Save Local</button>
+            <button id="loadLocalBtn" class="btn">Load Local</button>
+            <button id="exportBtn" class="btn btn-blue">Export JSON</button>
+            <label class="btn file-btn">Import JSON<input id="importInput" type="file" accept="application/json" /></label>
+          </div>
+          <textarea id="jsonPreview" rows="6" readonly></textarea>
+        </section>
+      </main>
+    </div>
+
+    <template id="mixerChannelTemplate">
+      <div class="channel">
+        <h3></h3>
+        <label>Level<input type="range" min="0" max="127" data-param="level" /></label>
+        <label>Pitch<input type="range" min="-24" max="24" data-param="pitch" /></label>
+        <label>Pan<input type="range" min="-64" max="63" data-param="pan" /></label>
+        <label>FX Send<input type="range" min="0" max="127" data-param="fx" /></label>
+        <div class="channel-actions">
+          <button class="btn small" data-action="mute">MUTE</button>
+          <button class="btn small" data-action="solo">SOLO</button>
+          <button class="btn small" data-action="audition">HIT</button>
+        </div>
+      </div>
+    </template>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/web/korg-editor/script.js
+++ b/web/korg-editor/script.js
@@ -1,0 +1,443 @@
+const PARTS = ["KICK", "SNARE", "HH", "CLAP", "PERC", "SYNTH 1", "SYNTH 2", "BASS", "FX", "AUDIO IN"];
+
+const createStep = () => ({ on: false, accent: false, ghost: false });
+const createPatternSteps = (length) => PARTS.map(() => Array.from({ length }, createStep));
+
+const state = {
+  model: "esx",
+  theme: "theme-esx",
+  patternName: "A.01 Detroit Bounce",
+  bpm: 128,
+  swing: 12,
+  patternLength: 16,
+  currentPage: 0,
+  selectedPart: 0,
+  masterVolume: 72,
+  steps: createPatternSteps(16),
+  mixer: PARTS.map(() => ({ level: 100, pitch: 0, pan: 0, fx: 20, mute: false, solo: false })),
+  motion: { cutoff: 78, resonance: 35, eg: 49, decay: 72, pan: 0, rollType: "Off" }
+};
+
+const refs = {
+  body: document.body,
+  partTabs: document.getElementById("partTabs"),
+  stepGrid: document.getElementById("stepGrid"),
+  mixer: document.getElementById("mixer"),
+  pageSelect: document.getElementById("pageSelect"),
+  jsonPreview: document.getElementById("jsonPreview"),
+  led: document.getElementById("ledDisplay")
+};
+
+let sequencerTimer = null;
+let currentStep = 0;
+let tapTimes = [];
+let audioCtx = null;
+const undoStack = [];
+const redoStack = [];
+
+function snapshot() {
+  undoStack.push(JSON.stringify(state));
+  if (undoStack.length > 60) undoStack.shift();
+  redoStack.length = 0;
+}
+
+function restoreFrom(raw) {
+  const parsed = JSON.parse(raw);
+  Object.assign(state, parsed);
+  syncInputs();
+  updatePageSelect();
+  applyTheme(state.theme);
+  setModel(state.model);
+  renderPartTabs();
+  renderSteps();
+  renderMixer();
+  refreshJSONPreview();
+}
+
+function undo() {
+  if (!undoStack.length) return;
+  redoStack.push(JSON.stringify(state));
+  restoreFrom(undoStack.pop());
+}
+
+function redo() {
+  if (!redoStack.length) return;
+  undoStack.push(JSON.stringify(state));
+  restoreFrom(redoStack.pop());
+}
+
+function updateLed(status) {
+  const page = state.currentPage + 1;
+  refs.led.textContent = `${state.patternName} | ${state.bpm} BPM | P${page} | ${status}`;
+}
+
+function getGlobalStepIndex(localStep) {
+  return state.currentPage * 16 + localStep;
+}
+
+function ensureAudio() {
+  if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+}
+
+function playTick(partIdx, isAccent = false) {
+  ensureAudio();
+  const now = audioCtx.currentTime;
+  const osc = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  const base = 90 + partIdx * 28;
+  osc.frequency.value = isAccent ? base + 80 : base;
+  gain.gain.value = (state.masterVolume / 100) * (isAccent ? 0.08 : 0.05);
+  osc.connect(gain).connect(audioCtx.destination);
+  osc.start(now);
+  osc.stop(now + 0.045);
+}
+
+function renderPartTabs() {
+  refs.partTabs.innerHTML = "";
+  PARTS.forEach((name, idx) => {
+    const btn = document.createElement("button");
+    btn.className = `part-tab ${idx === state.selectedPart ? "active" : ""}`;
+    btn.textContent = name;
+    btn.onclick = () => {
+      state.selectedPart = idx;
+      renderPartTabs();
+      renderSteps();
+      renderMixer();
+    };
+    refs.partTabs.appendChild(btn);
+  });
+}
+
+function renderSteps() {
+  refs.stepGrid.innerHTML = "";
+  for (let localIdx = 0; localIdx < 16; localIdx++) {
+    const globalIdx = getGlobalStepIndex(localIdx);
+    const stepData = state.steps[state.selectedPart][globalIdx];
+    const step = document.createElement("button");
+    step.className = `step ${stepData.on ? "on" : ""} ${stepData.accent ? "accent" : ""} ${stepData.ghost ? "ghost" : ""} ${globalIdx === currentStep ? "current" : ""}`;
+    step.innerHTML = `${localIdx + 1}<small>${stepData.accent ? "ACC" : stepData.ghost ? "GST" : ""}</small>`;
+
+    step.onclick = (e) => {
+      snapshot();
+      if (e.shiftKey) {
+        stepData.ghost = !stepData.ghost;
+        if (stepData.ghost) stepData.on = true;
+      } else {
+        stepData.on = !stepData.on;
+        if (!stepData.on) {
+          stepData.accent = false;
+          stepData.ghost = false;
+        }
+      }
+      renderSteps();
+      refreshJSONPreview();
+    };
+
+    step.oncontextmenu = (e) => {
+      e.preventDefault();
+      snapshot();
+      if (!stepData.on) stepData.on = true;
+      stepData.accent = !stepData.accent;
+      if (stepData.accent) stepData.ghost = false;
+      renderSteps();
+      refreshJSONPreview();
+    };
+
+    refs.stepGrid.appendChild(step);
+  }
+}
+
+function renderMixer() {
+  const template = document.getElementById("mixerChannelTemplate");
+  refs.mixer.innerHTML = "";
+  PARTS.forEach((name, idx) => {
+    const node = template.content.firstElementChild.cloneNode(true);
+    node.querySelector("h3").textContent = name;
+    const channel = state.mixer[idx];
+
+    if (channel.mute) node.classList.add("muted");
+    if (channel.solo) node.classList.add("solo");
+
+    node.querySelectorAll("[data-param]").forEach((input) => {
+      const key = input.dataset.param;
+      input.value = channel[key];
+      input.oninput = () => {
+        channel[key] = Number(input.value);
+        refreshJSONPreview();
+      };
+    });
+
+    node.querySelector('[data-action="mute"]').onclick = () => {
+      snapshot();
+      channel.mute = !channel.mute;
+      renderMixer();
+      refreshJSONPreview();
+    };
+    node.querySelector('[data-action="solo"]').onclick = () => {
+      snapshot();
+      channel.solo = !channel.solo;
+      renderMixer();
+      refreshJSONPreview();
+    };
+    node.querySelector('[data-action="audition"]').onclick = () => playTick(idx, true);
+
+    refs.mixer.appendChild(node);
+  });
+}
+
+function refreshJSONPreview() {
+  refs.jsonPreview.value = JSON.stringify(state, null, 2);
+}
+
+function nextStep() {
+  currentStep = (currentStep + 1) % state.patternLength;
+  const soloActive = state.mixer.some((c) => c.solo);
+  state.steps.forEach((partSteps, partIdx) => {
+    const channel = state.mixer[partIdx];
+    const step = partSteps[currentStep];
+    if (!step?.on) return;
+    if (channel.mute) return;
+    if (soloActive && !channel.solo) return;
+    playTick(partIdx, step.accent);
+  });
+  renderSteps();
+  updateLed("PLAY");
+}
+
+function startSequencer() {
+  stopSequencer(false);
+  const stepMs = (60_000 / state.bpm) / 4;
+  sequencerTimer = setInterval(nextStep, stepMs);
+  updateLed("PLAY");
+}
+
+function stopSequencer(reset = true) {
+  if (sequencerTimer) clearInterval(sequencerTimer);
+  sequencerTimer = null;
+  if (reset) currentStep = state.currentPage * 16;
+  renderSteps();
+  updateLed("STOP");
+}
+
+function fillPattern(type) {
+  snapshot();
+  const base = state.currentPage * 16;
+  const steps = state.steps[state.selectedPart];
+  for (let i = 0; i < 16; i++) {
+    if (type === "offbeat") steps[base + i] = { on: i % 2 === 1, accent: false, ghost: false };
+    else if (type === "four") steps[base + i] = { on: i % 4 === 0, accent: i % 8 === 0, ghost: false };
+    else steps[base + i] = createStep();
+  }
+  renderSteps();
+  refreshJSONPreview();
+}
+
+function randomizePattern() {
+  snapshot();
+  state.steps = state.steps.map((part) => part.map(() => ({
+    on: Math.random() > 0.62,
+    accent: Math.random() > 0.87,
+    ghost: Math.random() > 0.9
+  })));
+  renderSteps();
+  refreshJSONPreview();
+}
+
+function copyBar() {
+  snapshot();
+  if (state.patternLength < 32) return;
+  const steps = state.steps[state.selectedPart];
+  for (let i = 0; i < 16; i++) steps[i + 16] = { ...steps[i] };
+  renderSteps();
+  refreshJSONPreview();
+}
+
+function applyTheme(theme) {
+  refs.body.classList.remove("theme-esx", "theme-emx", "theme-night");
+  refs.body.classList.add(theme);
+  state.theme = theme;
+}
+
+function setModel(model) {
+  state.model = model;
+  refs.body.style.filter = model === "emx" ? "hue-rotate(16deg) saturate(1.15)" : "none";
+}
+
+function setPatternLength(length) {
+  snapshot();
+  const nextLength = Number(length);
+  const previous = state.patternLength;
+  if (nextLength === previous) return;
+  state.steps = state.steps.map((part) => {
+    const clone = [...part];
+    if (nextLength > previous) {
+      while (clone.length < nextLength) clone.push(createStep());
+    } else {
+      clone.length = nextLength;
+    }
+    return clone;
+  });
+  state.patternLength = nextLength;
+  state.currentPage = Math.min(state.currentPage, nextLength / 16 - 1);
+  currentStep = state.currentPage * 16;
+  updatePageSelect();
+  renderSteps();
+  refreshJSONPreview();
+}
+
+function updatePageSelect() {
+  refs.pageSelect.innerHTML = "";
+  const pages = state.patternLength / 16;
+  for (let i = 0; i < pages; i++) {
+    const opt = document.createElement("option");
+    opt.value = i;
+    opt.textContent = `Page ${i + 1}`;
+    refs.pageSelect.appendChild(opt);
+  }
+  refs.pageSelect.value = String(state.currentPage);
+}
+
+function saveLocal() {
+  localStorage.setItem("korgEditorPattern", JSON.stringify(state));
+  updateLed("SAVED");
+}
+
+function loadLocal() {
+  const data = localStorage.getItem("korgEditorPattern");
+  if (!data) return;
+  restoreFrom(data);
+  updateLed("LOADED");
+}
+
+function exportJSON() {
+  const blob = new Blob([JSON.stringify(state, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${state.patternName.replace(/\s+/g, "_") || "korg_pattern"}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function importJSON(file) {
+  const reader = new FileReader();
+  reader.onload = () => restoreFrom(String(reader.result));
+  reader.readAsText(file);
+}
+
+function syncInputs() {
+  document.getElementById("modelSelect").value = state.model;
+  document.getElementById("themeSelect").value = state.theme;
+  document.getElementById("patternName").value = state.patternName;
+  document.getElementById("bpmInput").value = state.bpm;
+  document.getElementById("swingInput").value = state.swing;
+  document.getElementById("patternLength").value = String(state.patternLength);
+  document.getElementById("masterVolume").value = String(state.masterVolume);
+  Object.entries(state.motion).forEach(([k, v]) => {
+    const el = document.getElementById(k);
+    if (el) el.value = v;
+  });
+}
+
+function bindEvents() {
+  document.getElementById("modelSelect").onchange = (e) => { setModel(e.target.value); refreshJSONPreview(); };
+  document.getElementById("themeSelect").onchange = (e) => { applyTheme(e.target.value); refreshJSONPreview(); };
+  document.getElementById("patternName").oninput = (e) => { state.patternName = e.target.value; updateLed("EDIT"); refreshJSONPreview(); };
+  document.getElementById("bpmInput").oninput = (e) => {
+    state.bpm = Number(e.target.value);
+    if (sequencerTimer) startSequencer();
+    refreshJSONPreview();
+  };
+  document.getElementById("swingInput").oninput = (e) => { state.swing = Number(e.target.value); refreshJSONPreview(); };
+  document.getElementById("patternLength").onchange = (e) => setPatternLength(e.target.value);
+  document.getElementById("pageSelect").onchange = (e) => {
+    state.currentPage = Number(e.target.value);
+    currentStep = state.currentPage * 16;
+    renderSteps();
+    refreshJSONPreview();
+  };
+  document.getElementById("masterVolume").oninput = (e) => { state.masterVolume = Number(e.target.value); refreshJSONPreview(); };
+
+  ["cutoff", "resonance", "eg", "decay", "pan", "rollType"].forEach((key) => {
+    document.getElementById(key).oninput = (e) => {
+      state.motion[key] = key === "rollType" ? e.target.value : Number(e.target.value);
+      refreshJSONPreview();
+    };
+  });
+
+  document.getElementById("playBtn").onclick = startSequencer;
+  document.getElementById("stopBtn").onclick = () => stopSequencer();
+
+  document.getElementById("tapBtn").onclick = () => {
+    const now = Date.now();
+    tapTimes.push(now);
+    if (tapTimes.length > 4) tapTimes = tapTimes.slice(-4);
+    if (tapTimes.length >= 2) {
+      const intervals = tapTimes.slice(1).map((t, i) => t - tapTimes[i]);
+      const avg = intervals.reduce((a, b) => a + b, 0) / intervals.length;
+      const bpm = Math.round(60_000 / avg);
+      if (bpm >= 40 && bpm <= 240) {
+        state.bpm = bpm;
+        document.getElementById("bpmInput").value = bpm;
+        if (sequencerTimer) startSequencer();
+      }
+    }
+    refreshJSONPreview();
+  };
+
+  document.getElementById("newPatternBtn").onclick = () => {
+    snapshot();
+    state.steps = createPatternSteps(state.patternLength);
+    renderSteps();
+    refreshJSONPreview();
+  };
+  document.getElementById("randomizeBtn").onclick = randomizePattern;
+  document.getElementById("copyBarBtn").onclick = copyBar;
+  document.getElementById("undoBtn").onclick = undo;
+  document.getElementById("redoBtn").onclick = redo;
+
+  document.querySelectorAll("[data-fill]").forEach((btn) => {
+    btn.onclick = () => fillPattern(btn.dataset.fill);
+  });
+
+  document.getElementById("saveLocalBtn").onclick = saveLocal;
+  document.getElementById("loadLocalBtn").onclick = loadLocal;
+  document.getElementById("exportBtn").onclick = exportJSON;
+  document.getElementById("importInput").onchange = (e) => {
+    const file = e.target.files?.[0];
+    if (file) importJSON(file);
+  };
+
+  document.addEventListener("keydown", (e) => {
+    if (e.code === "Space") {
+      e.preventDefault();
+      if (sequencerTimer) stopSequencer(); else startSequencer();
+    }
+    if (e.key === "z" && (e.ctrlKey || e.metaKey)) undo();
+    if (e.key === "y" && (e.ctrlKey || e.metaKey)) redo();
+    if (e.key === "ArrowRight") {
+      const maxPage = state.patternLength / 16 - 1;
+      state.currentPage = Math.min(state.currentPage + 1, maxPage);
+      refs.pageSelect.value = String(state.currentPage);
+      currentStep = state.currentPage * 16;
+      renderSteps();
+    }
+    if (e.key === "ArrowLeft") {
+      state.currentPage = Math.max(state.currentPage - 1, 0);
+      refs.pageSelect.value = String(state.currentPage);
+      currentStep = state.currentPage * 16;
+      renderSteps();
+    }
+  });
+}
+
+bindEvents();
+syncInputs();
+updatePageSelect();
+applyTheme(state.theme);
+setModel(state.model);
+renderPartTabs();
+renderSteps();
+renderMixer();
+refreshJSONPreview();
+updateLed("READY");

--- a/web/korg-editor/styles.css
+++ b/web/korg-editor/styles.css
@@ -1,0 +1,138 @@
+:root {
+  --panel: #d53a2b;
+  --panel-dark: #8e1a12;
+  --accent: #ffd83b;
+  --accent-2: #4dc7ff;
+  --text: #fff5ec;
+  --step-off: #150707;
+  --step-on: #ffcd3c;
+  --step-accent: #ffffff;
+  --step-ghost: #7c5c34;
+  --bg-1: #6f1212;
+  --bg-2: #180404;
+}
+
+* { box-sizing: border-box; font-family: "Segoe UI", system-ui, sans-serif; }
+body {
+  margin: 0;
+  color: var(--text);
+  background: radial-gradient(circle at top left, var(--bg-1), var(--bg-2) 60%);
+}
+
+.theme-esx {
+  --panel: #d53a2b; --panel-dark: #8e1a12; --accent: #ffd83b; --accent-2: #4dc7ff;
+  --step-off: #150707; --step-on: #ffcd3c; --step-accent: #ffffff; --step-ghost: #7c5c34;
+  --bg-1: #6f1212; --bg-2: #180404;
+}
+.theme-emx {
+  --panel: #2064b5; --panel-dark: #113569; --accent: #62e2ff; --accent-2: #ffe166;
+  --step-off: #051123; --step-on: #58ddff; --step-accent: #ffffff; --step-ghost: #315269;
+  --bg-1: #102a56; --bg-2: #050d1c;
+}
+.theme-night {
+  --panel: #2e2f33; --panel-dark: #16171a; --accent: #83ff9a; --accent-2: #2dffcf;
+  --step-off: #050605; --step-on: #90ff8e; --step-accent: #ffffff; --step-ghost: #35543c;
+  --bg-1: #23262a; --bg-2: #090b0d;
+}
+
+.app-shell { max-width: 1350px; margin: 1rem auto; padding: 1rem; }
+.panel {
+  background: linear-gradient(160deg, var(--panel), var(--panel-dark));
+  border: 2px solid color-mix(in srgb, var(--accent), #ffffff 18%);
+  border-radius: 12px;
+  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 35%), 0 10px 24px rgb(0 0 0 / 35%);
+  padding: 1rem;
+}
+.hardware { position: relative; }
+.hardware::before,
+.hardware::after {
+  content: ""; position: absolute; top: 10px; width: 14px; height: 14px; border-radius: 50%;
+  background: radial-gradient(#999, #333); border: 1px solid #111;
+}
+.hardware::before { left: 10px; }
+.hardware::after { right: 10px; }
+
+.brand { margin: 0; font-size: 0.75rem; letter-spacing: 0.12em; opacity: 0.85; }
+h1 { margin: 0.1rem 0; }
+.subtitle { margin: 0.2rem 0 0; opacity: 0.9; }
+.topbar { display: flex; justify-content: space-between; gap: 1rem; align-items: center; }
+.transport { display: flex; align-items: center; gap: 0.45rem; flex-wrap: wrap; justify-content: flex-end; }
+
+.led-display {
+  min-width: 210px;
+  padding: 0.36rem 0.55rem;
+  border: 1px solid #000;
+  border-radius: 6px;
+  background: #090c08;
+  color: #7dff65;
+  font-family: "Consolas", monospace;
+}
+
+.layout { margin-top: 1rem; display: grid; grid-template-columns: repeat(12, 1fr); gap: 0.9rem; }
+.machine-status { grid-column: span 4; }
+.design-section { grid-column: span 3; }
+.step-section { grid-column: span 8; }
+.mixer-section { grid-column: span 8; }
+.motion-section { grid-column: span 5; }
+.storage-section { grid-column: span 12; }
+
+.status-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.7rem; }
+label { display: flex; flex-direction: column; gap: 0.25rem; font-size: 0.85rem; }
+input, select, textarea {
+  background: #f8f5ef; color: #1f1513; border: 1px solid #0007; border-radius: 6px; padding: 0.4rem;
+}
+
+.btn {
+  border: 1px solid #0008; color: #fff; background: #4b4b53; border-radius: 7px;
+  padding: 0.45rem 0.7rem; font-weight: 700; cursor: pointer;
+}
+.btn-green { background: #22a939; }
+.btn-blue { background: #1d7ce2; }
+.btn-orange { background: #dd7c1f; }
+.btn.small { font-size: 0.75rem; padding: 0.32rem 0.45rem; }
+
+.actions-row, .storage-actions, .sequencer-tools {
+  display: flex; gap: 0.45rem; flex-wrap: wrap; margin-top: 0.8rem;
+}
+
+.legend { margin: 0.8rem 0 0; font-size: 0.83rem; opacity: 0.9; }
+
+.part-tabs { display: grid; grid-template-columns: repeat(10, minmax(0, 1fr)); gap: 0.25rem; margin-bottom: 0.6rem; }
+.part-tab {
+  border: 1px solid #0008; background: #f8f8f8; color: #2d1916; border-radius: 5px; padding: 0.3rem;
+  font-size: 0.8rem; cursor: pointer;
+}
+.part-tab.active { background: var(--accent); }
+
+.step-grid { display: grid; grid-template-columns: repeat(16, 1fr); gap: 0.2rem; }
+.step {
+  height: 56px; border-radius: 5px; border: 1px solid #0008;
+  background: var(--step-off); color: #fff; font-weight: 700; position: relative;
+}
+.step.on { background: var(--step-on); color: #1b1309; }
+.step.accent { box-shadow: inset 0 0 0 2px var(--step-accent); }
+.step.ghost { background: var(--step-ghost); }
+.step.current { outline: 2px solid var(--accent-2); }
+.step small { position: absolute; right: 4px; bottom: 3px; font-size: 0.62rem; }
+
+.mixer { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 0.5rem; }
+.channel {
+  background: color-mix(in srgb, var(--panel) 82%, #fff 18%);
+  border: 1px solid #0007; padding: 0.5rem; border-radius: 8px;
+}
+.channel h3 { margin: 0 0 0.35rem; font-size: 0.92rem; }
+.channel input[type="range"] { accent-color: var(--accent); }
+.channel-actions { display: flex; gap: 0.3rem; margin-top: 0.4rem; flex-wrap: wrap; }
+.channel.muted { opacity: 0.45; }
+.channel.solo { outline: 2px solid var(--accent); }
+
+.motion-grid { display: grid; gap: 0.5rem; }
+textarea { width: 100%; }
+.file-btn { position: relative; overflow: hidden; }
+.file-btn input { position: absolute; inset: 0; opacity: 0; cursor: pointer; }
+
+@media (max-width: 1000px) {
+  .machine-status, .design-section, .step-section, .mixer-section, .motion-section, .storage-section { grid-column: span 12; }
+  .mixer { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .part-tabs { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+}


### PR DESCRIPTION
### Motivation

- Provide a standalone browser-based pattern editor prototype for KORG ESX/EMX-1 to complement the existing Fabric client template.
- Offer an interactive UI for pattern design, auditioning and local persistence that can be used for rapid iteration and export/import of patterns.

### Description

- Adds a new `web/korg-editor/` prototype containing `index.html`, `script.js`, and `styles.css` which implement a 10-part step sequencer UI, mixer, motion controls, and pattern manager.
- Implements playback/audio-preview using the WebAudio API, tap tempo, sequencer start/stop, page switching, adjustable pattern lengths (16/32/64), page copy, fill/randomize tools, undo/redo history, and per-part mute/solo/audition in `script.js`.
- Adds theme support, local save/load, JSON import/export, and a live JSON preview of the pattern state, and wire-up of controls and keyboard shortcuts in the UI.
- Updates `README.md` with a new section `KORG ESX/EMX-1 Web Editor (Prototype)` and includes local run instructions using `python3 -m http.server 4173` and the editor path `web/korg-editor/index.html`.

### Testing

- No automated tests were added or executed for this prototype.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a28e24eaf0832886978055e264e3b6)